### PR TITLE
Privacy Options

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,7 @@ RedirectMatch 404 /*\.json
 | `enableRegister`   | Enable or disable registration function                                     | yes       |
 | `enableUnregister` | Enable or disable unregistration function                                   | yes       |
 | `hideNames`        | Hide registered names in shift overview                                     | yes       |
+| `hidePdfExport`    | Disable pdf export feature in UI                                            | yes       |
 | `mail.username`    | Username for SMTP server                                                    | yes       |
 | `mail.password`    | Password for SMTP server                                                    | yes       |
 | `mail.smtpserv`    | Address of SMTP server (notice: we always connect via STARTTLS on port 587) | yes       |
@@ -57,6 +58,10 @@ Just run `make test` (because Makefiles are superior). This will host a local we
 ## Data access
 If you want to get a list of all entries with contact information, just call `<baseUrl>?action=csvexport`.
 The system will send a mail with all entries as a csv file to the configured admin mail address.
+**Attention!** From now on, the pdf plan is also attached to this mail.
+
+## Data privacy
+If you want to prevent others from seeing all entry names, you can use the two config options `hideNames` and `hidePdfExport` together. If set, all names are only visible via the export feature which sents this data to the admin mail address.
 
 ## Contribution
 If you want to contribute: Feel free! 

--- a/README.md
+++ b/README.md
@@ -24,19 +24,20 @@ RedirectMatch 404 /*\.json
 
 
 ### Details: `config.json`
-| Key               | Description                                                                 | Required  |
-|-------------------|-----------------------------------------------------------------------------|-----------|
-| `shiftFile`       | Path to JSON with shift definitions (see next chapter)                      | yes       |
-| `adminMail`       | Mail address of the administrator who will receive the csv export           | yes       |
-| `baseUrl`         | The base URL of the service, usually ending with `index.php`                | yes       |
-| `hashSalt`        | Salt for the registration hashs                                             | yes       |
-| `enableRegister`  | Enable or disable registration function                                     | yes       |
-| `enableUnegister` | Enable or disable unregistration function                                   | yes       |
-| `mail.username`   | Username for SMTP server                                                    | yes       |
-| `mail.password`   | Password for SMTP server                                                    | yes       |
-| `mail.smtpserv`   | Address of SMTP server (notice: we always connect via STARTTLS on port 587) | yes       |
-| `mail.fromaddress`| Sender's mail address                                                       | yes       |
-| `mail.fromname`   | Sender's human readable name                                                | yes       |
+| Key                | Description                                                                 | Required  |
+|--------------------|-----------------------------------------------------------------------------|-----------|
+| `shiftFile`        | Path to JSON with shift definitions (see next chapter)                      | yes       |
+| `adminMail`        | Mail address of the administrator who will receive the csv export           | yes       |
+| `baseUrl`          | The base URL of the service, usually ending with `index.php`                | yes       |
+| `hashSalt`         | Salt for the registration hashs                                             | yes       |
+| `enableRegister`   | Enable or disable registration function                                     | yes       |
+| `enableUnregister` | Enable or disable unregistration function                                   | yes       |
+| `hideNames`        | Hide registered names in shift overview                                     | yes       |
+| `mail.username`    | Username for SMTP server                                                    | yes       |
+| `mail.password`    | Password for SMTP server                                                    | yes       |
+| `mail.smtpserv`    | Address of SMTP server (notice: we always connect via STARTTLS on port 587) | yes       |
+| `mail.fromaddress` | Sender's mail address                                                       | yes       |
+| `mail.fromname`    | Sender's human readable name                                                | yes       |
 
 *The key name in this table follows the syntax `key.subkey` => `{"key": {"subkey": value}}`*
 

--- a/index.php
+++ b/index.php
@@ -87,6 +87,7 @@ switch ($action) {
         }
         break;
     case "pdfexport":
+        if($config["hidePdfExport"]) die("config option 'hidePdfExport' is set. abort.");
         handlePdfExport($config, $eventInfo);
         exit(0);
     case "csvexport":

--- a/index.php
+++ b/index.php
@@ -100,6 +100,9 @@ calculcateOccupancy($eventInfo);
 /* add special css classes */
 appendClasses($eventInfo);
 
+/* hide names */
+if($config["hideNames"]) hideEntryNames($eventInfo);
+
 /* read authors from file */
 //$authors = implode(", ", explode("\n", file_get_contents("./AUTHORS")));
 $authors = implode(

--- a/src/csvexport.php
+++ b/src/csvexport.php
@@ -14,12 +14,14 @@ function handleCsvExport($config, &$eventInfo) {
                 $result .= html_entity_decode($task["taskName"]) . $colDelim;
                 $result .= html_entity_decode($shift["shiftName"]) . $colDelim;
                 $result .= html_entity_decode($entry["entryName"]) . $colDelim;
-                $result .= html_entity_decode($entry["entryMail"]) . $colDelim;
+                $result .= html_entity_decode($entry["entryMail"] ?? "") . $colDelim;
                 $result .= date(DATE_ATOM, $entry["entryTimestamp"] ?? 0);
                 $result .= $rowDelim;
             }
         }
     }
+    /* generate pdf file */
+    $binaryPdf = exportPdfAsString($config, $eventInfo);
     /* generate admin mail */
     $mail = new PHPMailer(true);
     try {
@@ -40,6 +42,7 @@ function handleCsvExport($config, &$eventInfo) {
         $mail->Subject = "EXPORT Helfiliste " . $eventInfo["eventName"];
         $mail->Body = "see attachment";
         $mail->AddStringAttachment($result, "export.csv");
+        $mail->AddStringAttachment($binaryPdf, "plan.pdf");
         $mail->send();
         echo "mail sent, everything okay";
     } catch (Exception $e) {

--- a/src/pdfexport.php
+++ b/src/pdfexport.php
@@ -37,9 +37,8 @@ class PDF extends tFPDF {
     }
 }
 
-function handlePdfExport($config, &$eventInfo) {
+function buildPdf($config, &$eventInfo) {
     $pdf = new PDF($eventInfo, 'L', 'mm', 'A4');
-
     foreach ($eventInfo["eventTasks"] as $task) {
         /* page creation and title */
         $pdf->AddPage();
@@ -96,9 +95,18 @@ function handlePdfExport($config, &$eventInfo) {
             $slot++;
         }
     }
+    return $pdf;
+}
+function handlePdfExport($config, &$eventInfo) {
+    $pdf = buildPdf($config, $eventInfo);
     /* force uncached output */
     header("Cache-Control: no-store, no-cache, must-revalidate, max-age=0");
     header("Cache-Control: post-check=0, pre-check=0", false);
     header("Pragma: no-cache");
     $pdf->Output("I");
+}
+
+function exportPdfAsString($config, &$eventInfo) {
+    $pdf = buildPdf($config, $eventInfo);
+    return $pdf->Output("S");
 }

--- a/src/utils.php
+++ b/src/utils.php
@@ -59,4 +59,17 @@ function appendClasses(&$eventInfo) {
     }
 }
 
+function hideEntryNames(&$eventInfo) {
+    foreach($eventInfo["eventTasks"] as $taskIndex => &$task) {
+        foreach($task["taskShifts"] as $shiftIndex => &$shift) {
+            if(isset($shift["entries"])) {
+                foreach($shift["entries"] as $entryIndex => &$entry) {
+                    $entry["entryName"] = "<i>belegt</i>";
+                    $entry["entryClass"] .= "";
+                }
+            } 
+        }
+    }
+}
+
 ?>

--- a/static/css/style.css
+++ b/static/css/style.css
@@ -220,9 +220,18 @@ h2, h3, h4, h5, h6 {
 
 .progress-text {
   position: relative;
-  font-size: 10px;
+  font-size: 8px;
   font-weight: bold;
   color: var(--text);
+}
+
+/* small variant for shifts */
+.progress-ring-small {
+    --size: 24px;
+}
+
+.progress-ring-small .progress-text {
+    font-size: 5.5px;
 }
 
 

--- a/template.htm
+++ b/template.htm
@@ -97,9 +97,11 @@
                 <a href="javascript:shareDialog();" class="header-icon">
                     <i class="si-share"></i>
                 </a>
+                <?php if( ! $config["hidePdfExport"]) { ?>
                 <a href="?action=pdfexport" class="header-icon">
                     <i class="si-printer"></i>
                 </a>
+                <?php } ?>
                 <span class="fsi-logo">fsi</span>
             </section>
         </header>

--- a/template.htm
+++ b/template.htm
@@ -145,7 +145,9 @@
                         <i class="icon icon-arrow-right mr-1"></i> 
                         <i class="si-pin"></i>
                         <?=$task["taskName"]?>
-                        <span class="chip chip-occupancy" style="background: <?=$task["occupancyColor"]?>"><?=$task["occupancyString"]?></span>
+                        <span class="chip chip-occupancy progress-ring" style="--progress: <?=$task["occupancyPercentage"] * 100?>; --fill-color: <?=$task["occupancyColor"]?>">
+                            <span class="progress-text"><?=$task["occupancyString"]?></span>
+                        </span>
                     </h3>
                 </label>
                 <div class="accordion-body">
@@ -161,7 +163,9 @@
                                     <i class="icon icon-time mr-1"></i>
                                     <?=$shift["shiftName"]?> 
                                     <?=isset($shift["shiftDesc"]) ? "<small class='chip bg-primary'>".$shift["shiftDesc"]."</small>" : ""?>
-                                    <span class="chip chip-occupancy" style="background: <?=$shift["occupancyColor"]?>"><?=$shift["occupancyString"]?></span>
+                                    <span class="chip chip-occupancy progress-ring progress-ring-small" style="--progress: <?=$shift["occupancyPercentage"] * 100?>; --fill-color: <?=$shift["occupancyColor"]?>">
+                                        <span class="progress-text"><?=$shift["occupancyString"]?></span>
+                                    </span>
                                 </h5>
                             </label>
                             <div class="accordion-body">


### PR DESCRIPTION
This PR adds two new config options:
- `hideNames` to hide all names at the shift overview and simply replace them with a generic "belegt" string
- `hidePdfExport` to hide (and partly disable) the pdf export feature. The pdf shift schedule will only be sent to the admin mail address if `?action=csvExport` is called.

The two config options described above address issue #15.

This PR also updates the appearence of the occupancy indicators on the individual shifts to the design used at the bottom of the page.